### PR TITLE
Update openshift-cert-manager-operator-master.yaml

### DIFF
--- a/ci-operator/config/openshift/cert-manager-operator/openshift-cert-manager-operator-master.yaml
+++ b/ci-operator/config/openshift/cert-manager-operator/openshift-cert-manager-operator-master.yaml
@@ -84,7 +84,7 @@ tests:
       OO_INDEX: ci-index-cert-manager-operator-bundle
     env:
       OO_CHANNEL: alpha
-      OO_INSTALL_NAMESPACE: openshift-marketplace
+      OO_INSTALL_NAMESPACE: cert-manager-operator
       OO_PACKAGE: cert-manager-operator
       OO_TARGET_NAMESPACES: '!install'
     test:


### PR DESCRIPTION
Update `OO_INSTALL_NAMESPACE: cert-manager-operator` since, https://github.com/openshift/release/pull/35233 issue on `optional-operator-subscribe` has been fixed. 